### PR TITLE
Add backward-compatibility bridge shims for 7.1.x

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/config/GrailsApplicationPostProcessor.groovy
+++ b/grails-core/src/main/groovy/grails/boot/config/GrailsApplicationPostProcessor.groovy
@@ -98,6 +98,24 @@ class GrailsApplicationPostProcessor implements BeanDefinitionRegistryPostProces
         }
     }
 
+    /**
+     * @deprecated Use {@link #GrailsApplicationPostProcessor(GrailsApplicationLifeCycle, ApplicationContext, GrailsPluginDiscovery, Class[])} instead.
+     * Plugin discovery is now provided explicitly. This constructor creates a default discovery instance.
+     * Will be removed in Grails 8.0.0.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    GrailsApplicationPostProcessor(GrailsApplicationLifeCycle lifeCycle, ApplicationContext applicationContext, Class...classes) {
+        this(lifeCycle, applicationContext, new org.apache.grails.core.plugins.DefaultGrailsPluginDiscovery(), classes)
+    }
+
+    /**
+     * @deprecated Plugin manager customization is now handled through {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}.
+     * This method is a no-op and will be removed in Grails 8.0.0.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    protected void customizePluginManager(GrailsPluginManager pluginManager) {
+    }
+
     protected final void initializeGrailsApplication(ApplicationContext applicationContext) {
         if (applicationContext == null) {
             throw new IllegalStateException('ApplicationContext should not be null')

--- a/grails-core/src/main/groovy/grails/boot/config/GrailsApplicationPostProcessor.groovy
+++ b/grails-core/src/main/groovy/grails/boot/config/GrailsApplicationPostProcessor.groovy
@@ -109,23 +109,34 @@ class GrailsApplicationPostProcessor implements BeanDefinitionRegistryPostProces
     }
 
     /**
-     * Resolves the {@link GrailsPluginDiscovery} from the application context if available,
-     * otherwise creates a new default instance. The bootstrap registry promotes the discovery
-     * bean before context refresh, so it is safe to look up by bean name at this stage.
+     * Resolves the {@link GrailsPluginDiscovery} from the application context.
+     * The bootstrap registry promotes the discovery bean before context refresh,
+     * so it is always available by bean name at this stage.
+     *
+     * @throws IllegalStateException if the application context is null or does not contain a GrailsPluginDiscovery bean
      */
     private static GrailsPluginDiscovery resolvePluginDiscovery(ApplicationContext applicationContext) {
-        if (applicationContext != null && applicationContext.containsBean(GrailsPluginDiscovery.BEAN_NAME)) {
-            return (GrailsPluginDiscovery) applicationContext.getBean(GrailsPluginDiscovery.BEAN_NAME)
+        if (applicationContext == null || !applicationContext.containsBean(GrailsPluginDiscovery.BEAN_NAME)) {
+            throw new IllegalStateException(
+                    'GrailsPluginDiscovery bean not found in ApplicationContext. ' +
+                    'Use GrailsApplicationPostProcessor(GrailsApplicationLifeCycle, ApplicationContext, GrailsPluginDiscovery, Class[]) instead.'
+            )
         }
-        return new org.apache.grails.core.plugins.DefaultGrailsPluginDiscovery()
+        return (GrailsPluginDiscovery) applicationContext.getBean(GrailsPluginDiscovery.BEAN_NAME)
     }
 
     /**
      * @deprecated Plugin manager customization is now handled through {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}.
-     * This method is a no-op and will be removed in Grails 8.0.0.
+     * This method will be removed in Grails 8.0.0.
+     *
+     * @throws UnsupportedOperationException always - callers must switch to {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}
      */
     @Deprecated(forRemoval = true, since = "7.1")
     protected void customizePluginManager(GrailsPluginManager pluginManager) {
+        throw new UnsupportedOperationException(
+                'customizePluginManager() is no longer supported. ' +
+                'Use org.apache.grails.core.plugins.GrailsPluginDiscovery to configure plugin discovery instead.'
+        )
     }
 
     protected final void initializeGrailsApplication(ApplicationContext applicationContext) {

--- a/grails-core/src/main/groovy/grails/boot/config/GrailsApplicationPostProcessor.groovy
+++ b/grails-core/src/main/groovy/grails/boot/config/GrailsApplicationPostProcessor.groovy
@@ -100,12 +100,24 @@ class GrailsApplicationPostProcessor implements BeanDefinitionRegistryPostProces
 
     /**
      * @deprecated Use {@link #GrailsApplicationPostProcessor(GrailsApplicationLifeCycle, ApplicationContext, GrailsPluginDiscovery, Class[])} instead.
-     * Plugin discovery is now provided explicitly. This constructor creates a default discovery instance.
+     * Plugin discovery is resolved from the application context when available, otherwise a default instance is created.
      * Will be removed in Grails 8.0.0.
      */
     @Deprecated(forRemoval = true, since = "7.1")
     GrailsApplicationPostProcessor(GrailsApplicationLifeCycle lifeCycle, ApplicationContext applicationContext, Class...classes) {
-        this(lifeCycle, applicationContext, new org.apache.grails.core.plugins.DefaultGrailsPluginDiscovery(), classes)
+        this(lifeCycle, applicationContext, resolvePluginDiscovery(applicationContext), classes)
+    }
+
+    /**
+     * Resolves the {@link GrailsPluginDiscovery} from the application context if available,
+     * otherwise creates a new default instance. The bootstrap registry promotes the discovery
+     * bean before context refresh, so it is safe to look up by bean name at this stage.
+     */
+    private static GrailsPluginDiscovery resolvePluginDiscovery(ApplicationContext applicationContext) {
+        if (applicationContext != null && applicationContext.containsBean(GrailsPluginDiscovery.BEAN_NAME)) {
+            return (GrailsPluginDiscovery) applicationContext.getBean(GrailsPluginDiscovery.BEAN_NAME)
+        }
+        return new org.apache.grails.core.plugins.DefaultGrailsPluginDiscovery()
     }
 
     /**

--- a/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
@@ -96,32 +96,32 @@ public class DefaultGrailsPluginManager extends AbstractGrailsPluginManager {
 
     /**
      * @deprecated Use {@link #DefaultGrailsPluginManager(GrailsApplication, GrailsPluginDiscovery)} instead.
-     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor creates a default
-     * discovery instance. Will be removed in Grails 8.0.0.
+     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor forwards
+     * the resource path to the discovery instance. Will be removed in Grails 8.0.0.
      */
     @Deprecated(forRemoval = true, since = "7.1")
     public DefaultGrailsPluginManager(String resourcePath, GrailsApplication application) {
-        this(application, new DefaultGrailsPluginDiscovery());
+        this(application, new DefaultGrailsPluginDiscovery(resourcePath));
     }
 
     /**
      * @deprecated Use {@link #DefaultGrailsPluginManager(GrailsApplication, GrailsPluginDiscovery)} instead.
-     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor creates a default
-     * discovery instance. Will be removed in Grails 8.0.0.
+     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor forwards
+     * the plugin resources to the discovery instance. Will be removed in Grails 8.0.0.
      */
     @Deprecated(forRemoval = true, since = "7.1")
     public DefaultGrailsPluginManager(String[] pluginResources, GrailsApplication application) {
-        this(application, new DefaultGrailsPluginDiscovery());
+        this(application, new DefaultGrailsPluginDiscovery(pluginResources));
     }
 
     /**
      * @deprecated Use {@link #DefaultGrailsPluginManager(GrailsApplication, GrailsPluginDiscovery)} instead.
-     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor creates a default
-     * discovery instance. Will be removed in Grails 8.0.0.
+     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor forwards
+     * the plugin classes to the discovery instance. Will be removed in Grails 8.0.0.
      */
     @Deprecated(forRemoval = true, since = "7.1")
     public DefaultGrailsPluginManager(Class<?>[] plugins, GrailsApplication application) {
-        this(application, new DefaultGrailsPluginDiscovery());
+        this(application, new DefaultGrailsPluginDiscovery(plugins));
     }
 
     public GrailsPlugin[] getUserPlugins() {

--- a/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
@@ -41,6 +41,7 @@ import org.springframework.core.io.Resource;
 import grails.core.GrailsApplication;
 import grails.core.support.ParentApplicationContextAware;
 import grails.plugins.exceptions.PluginException;
+import org.apache.grails.core.plugins.DefaultGrailsPluginDiscovery;
 import org.apache.grails.core.plugins.GrailsPluginDescriptor;
 import org.apache.grails.core.plugins.GrailsPluginDiscovery;
 import org.apache.grails.core.plugins.GrailsPluginInfo;
@@ -91,6 +92,36 @@ public class DefaultGrailsPluginManager extends AbstractGrailsPluginManager {
 
     public DefaultGrailsPluginManager(GrailsApplication application, GrailsPluginDiscovery pluginDiscovery) {
         super(application, pluginDiscovery);
+    }
+
+    /**
+     * @deprecated Use {@link #DefaultGrailsPluginManager(GrailsApplication, GrailsPluginDiscovery)} instead.
+     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor creates a default
+     * discovery instance. Will be removed in Grails 8.0.0.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public DefaultGrailsPluginManager(String resourcePath, GrailsApplication application) {
+        this(application, new DefaultGrailsPluginDiscovery());
+    }
+
+    /**
+     * @deprecated Use {@link #DefaultGrailsPluginManager(GrailsApplication, GrailsPluginDiscovery)} instead.
+     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor creates a default
+     * discovery instance. Will be removed in Grails 8.0.0.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public DefaultGrailsPluginManager(String[] pluginResources, GrailsApplication application) {
+        this(application, new DefaultGrailsPluginDiscovery());
+    }
+
+    /**
+     * @deprecated Use {@link #DefaultGrailsPluginManager(GrailsApplication, GrailsPluginDiscovery)} instead.
+     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor creates a default
+     * discovery instance. Will be removed in Grails 8.0.0.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public DefaultGrailsPluginManager(Class<?>[] plugins, GrailsApplication application) {
+        this(application, new DefaultGrailsPluginDiscovery());
     }
 
     public GrailsPlugin[] getUserPlugins() {

--- a/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
@@ -41,7 +41,6 @@ import org.springframework.core.io.Resource;
 import grails.core.GrailsApplication;
 import grails.core.support.ParentApplicationContextAware;
 import grails.plugins.exceptions.PluginException;
-import org.apache.grails.core.plugins.DefaultGrailsPluginDiscovery;
 import org.apache.grails.core.plugins.GrailsPluginDescriptor;
 import org.apache.grails.core.plugins.GrailsPluginDiscovery;
 import org.apache.grails.core.plugins.GrailsPluginInfo;
@@ -96,32 +95,48 @@ public class DefaultGrailsPluginManager extends AbstractGrailsPluginManager {
 
     /**
      * @deprecated Use {@link #DefaultGrailsPluginManager(GrailsApplication, GrailsPluginDiscovery)} instead.
-     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor forwards
-     * the resource path to the discovery instance. Will be removed in Grails 8.0.0.
+     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor fetches the
+     * existing discovery bean, resets and reinitializes it. Will be removed in Grails 8.0.0.
      */
     @Deprecated(forRemoval = true, since = "7.1")
     public DefaultGrailsPluginManager(String resourcePath, GrailsApplication application) {
-        this(application, new DefaultGrailsPluginDiscovery(resourcePath));
+        this(application, resolveAndReinitializeDiscovery(application));
     }
 
     /**
      * @deprecated Use {@link #DefaultGrailsPluginManager(GrailsApplication, GrailsPluginDiscovery)} instead.
-     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor forwards
-     * the plugin resources to the discovery instance. Will be removed in Grails 8.0.0.
+     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor fetches the
+     * existing discovery bean, resets and reinitializes it. Will be removed in Grails 8.0.0.
      */
     @Deprecated(forRemoval = true, since = "7.1")
     public DefaultGrailsPluginManager(String[] pluginResources, GrailsApplication application) {
-        this(application, new DefaultGrailsPluginDiscovery(pluginResources));
+        this(application, resolveAndReinitializeDiscovery(application));
     }
 
     /**
      * @deprecated Use {@link #DefaultGrailsPluginManager(GrailsApplication, GrailsPluginDiscovery)} instead.
-     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor forwards
-     * the plugin classes to the discovery instance. Will be removed in Grails 8.0.0.
+     * Plugin discovery is now handled by {@link GrailsPluginDiscovery}. This constructor fetches the
+     * existing discovery bean, resets and reinitializes it. Will be removed in Grails 8.0.0.
      */
     @Deprecated(forRemoval = true, since = "7.1")
     public DefaultGrailsPluginManager(Class<?>[] plugins, GrailsApplication application) {
-        this(application, new DefaultGrailsPluginDiscovery(plugins));
+        this(application, resolveAndReinitializeDiscovery(application));
+    }
+
+    /**
+     * Resolves the {@link GrailsPluginDiscovery} bean from the application context,
+     * resets and reinitializes it. The GrailsApplication always has an application context
+     * set when these deprecated constructors are called.
+     */
+    private static GrailsPluginDiscovery resolveAndReinitializeDiscovery(GrailsApplication application) {
+        ApplicationContext ctx = application.getMainContext();
+        GrailsPluginDiscovery discovery = (GrailsPluginDiscovery) ctx.getBean(GrailsPluginDiscovery.BEAN_NAME);
+        LOG.warn("Using deprecated DefaultGrailsPluginManager constructor. " +
+                "Plugin discovery should be configured through the GrailsPluginDiscovery bean. " +
+                "Reinitializing plugin discovery.");
+        discovery.reset();
+        discovery.init(ctx.getEnvironment());
+        return discovery;
     }
 
     public GrailsPlugin[] getUserPlugins() {

--- a/grails-core/src/main/groovy/grails/plugins/GrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/GrailsPluginManager.java
@@ -320,4 +320,24 @@ public interface GrailsPluginManager extends ApplicationContextAware {
      * @return True if it was shutdown
      */
     boolean isShutdown();
+
+    /**
+     * Set whether the core plugins should be loaded.
+     *
+     * @param shouldLoadCorePlugins True if they should
+     * @deprecated Core plugin loading is now handled by {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}.
+     * This method is a no-op and will be removed in Grails 8.0.0.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    void setLoadCorePlugins(boolean shouldLoadCorePlugins);
+
+    /**
+     * Sets the filter to use to filter for plugins.
+     *
+     * @param pluginFilter The plugin filter
+     * @deprecated Plugin filtering is now handled by {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}.
+     * This method is a no-op and will be removed in Grails 8.0.0.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    void setPluginFilter(PluginFilter pluginFilter);
 }

--- a/grails-core/src/main/groovy/org/apache/grails/core/plugins/DefaultGrailsPluginDiscovery.java
+++ b/grails-core/src/main/groovy/org/apache/grails/core/plugins/DefaultGrailsPluginDiscovery.java
@@ -53,7 +53,6 @@ public class DefaultGrailsPluginDiscovery implements GrailsPluginDiscovery {
     protected boolean loadClasspathPlugins = true;
     protected boolean requireClasspathPlugin = true;
     protected final PluginFilterRetriever filterRetriever;
-    private boolean initialized = false;
 
     public DefaultGrailsPluginDiscovery() {
         this(new PluginFilterRetriever());
@@ -110,7 +109,7 @@ public class DefaultGrailsPluginDiscovery implements GrailsPluginDiscovery {
     }
 
     public void init(Environment environment) {
-        if (!initialized) {
+        if (plugins == null) {
             if (environment == null) {
                 throw new IllegalArgumentException("Environment must be provided to determine plugin order");
             }
@@ -246,6 +245,7 @@ public class DefaultGrailsPluginDiscovery implements GrailsPluginDiscovery {
         List<GrailsPluginInfo> filteredPlugins = filterPlugins(allPlugins, environment);
 
         reset();
+        plugins = new LinkedHashMap<>();
 
         if (filteredPlugins.isEmpty()) {
             LOG.debug("All plugins were excluded by plugin filtering");
@@ -268,7 +268,6 @@ public class DefaultGrailsPluginDiscovery implements GrailsPluginDiscovery {
                 GrailsPluginInfo::loadAfterNames,
                 GrailsPluginInfo::loadBeforeNames
         );
-        initialized = true;
     }
 
     private void processDelayedEvictions() {
@@ -554,8 +553,8 @@ public class DefaultGrailsPluginDiscovery implements GrailsPluginDiscovery {
 
     @Override
     public void reset() {
-        initialized = false;
-        plugins = new LinkedHashMap<>();
+        LOG.warn("Resetting plugin discovery - plugins will be reloaded on next init()");
+        plugins = null;
         loadOrderedPlugins = new ArrayList<>();
         pluginToObserverMap = new HashMap<>();
         delayedLoadPlugins = new LinkedList<>();

--- a/grails-core/src/main/groovy/org/apache/grails/core/plugins/DefaultGrailsPluginDiscovery.java
+++ b/grails-core/src/main/groovy/org/apache/grails/core/plugins/DefaultGrailsPluginDiscovery.java
@@ -53,6 +53,7 @@ public class DefaultGrailsPluginDiscovery implements GrailsPluginDiscovery {
     protected boolean loadClasspathPlugins = true;
     protected boolean requireClasspathPlugin = true;
     protected final PluginFilterRetriever filterRetriever;
+    private boolean initialized = false;
 
     public DefaultGrailsPluginDiscovery() {
         this(new PluginFilterRetriever());
@@ -109,7 +110,7 @@ public class DefaultGrailsPluginDiscovery implements GrailsPluginDiscovery {
     }
 
     public void init(Environment environment) {
-        if (plugins == null) {
+        if (!initialized) {
             if (environment == null) {
                 throw new IllegalArgumentException("Environment must be provided to determine plugin order");
             }
@@ -267,6 +268,7 @@ public class DefaultGrailsPluginDiscovery implements GrailsPluginDiscovery {
                 GrailsPluginInfo::loadAfterNames,
                 GrailsPluginInfo::loadBeforeNames
         );
+        initialized = true;
     }
 
     private void processDelayedEvictions() {
@@ -552,6 +554,7 @@ public class DefaultGrailsPluginDiscovery implements GrailsPluginDiscovery {
 
     @Override
     public void reset() {
+        initialized = false;
         plugins = new LinkedHashMap<>();
         loadOrderedPlugins = new ArrayList<>();
         pluginToObserverMap = new HashMap<>();

--- a/grails-core/src/main/groovy/org/grails/plugins/AbstractGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/AbstractGrailsPluginManager.java
@@ -389,20 +389,38 @@ public abstract class AbstractGrailsPluginManager implements GrailsPluginManager
 
     /**
      * @deprecated Core plugin loading is now handled by {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}.
-     * This method is a no-op and will be removed in Grails 8.0.0.
+     * Use {@link org.apache.grails.core.plugins.GrailsPluginDiscovery#setLoadClasspathPlugins(boolean)} instead.
+     * This method will be removed in Grails 8.0.0.
      */
     @Deprecated(forRemoval = true, since = "7.1")
     @Override
     public void setLoadCorePlugins(boolean shouldLoadCorePlugins) {
+        pluginDiscovery.setLoadClasspathPlugins(shouldLoadCorePlugins);
+        reinitializeDiscovery();
     }
 
     /**
      * @deprecated Plugin filtering is now handled by {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}.
-     * This method is a no-op and will be removed in Grails 8.0.0.
+     * Use {@link org.apache.grails.core.plugins.GrailsPluginDiscovery#setPluginFilter(PluginFilter)} instead.
+     * This method will be removed in Grails 8.0.0.
      */
     @Deprecated(forRemoval = true, since = "7.1")
     @Override
     public void setPluginFilter(PluginFilter pluginFilter) {
+        pluginDiscovery.setPluginFilter(pluginFilter);
+        reinitializeDiscovery();
+    }
+
+    /**
+     * Resets and reinitializes plugin discovery if an application context is available.
+     * When called before the application context is set (the typical pre-startup case),
+     * the forwarded settings will be picked up during normal lifecycle initialization.
+     */
+    private void reinitializeDiscovery() {
+        if (applicationContext != null) {
+            pluginDiscovery.reset();
+            pluginDiscovery.init(applicationContext.getEnvironment());
+        }
     }
 
     public void informOfClassChange(Class<?> aClass) {

--- a/grails-core/src/main/groovy/org/grails/plugins/AbstractGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/AbstractGrailsPluginManager.java
@@ -54,6 +54,7 @@ import grails.core.ArtefactHandler;
 import grails.core.GrailsApplication;
 import grails.plugins.GrailsPlugin;
 import grails.plugins.GrailsPluginManager;
+import grails.plugins.PluginFilter;
 import grails.plugins.Plugin;
 import grails.plugins.exceptions.PluginException;
 import grails.util.Environment;
@@ -384,6 +385,24 @@ public abstract class AbstractGrailsPluginManager implements GrailsPluginManager
 
     public boolean isShutdown() {
         return shutdown;
+    }
+
+    /**
+     * @deprecated Core plugin loading is now handled by {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}.
+     * This method is a no-op and will be removed in Grails 8.0.0.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    @Override
+    public void setLoadCorePlugins(boolean shouldLoadCorePlugins) {
+    }
+
+    /**
+     * @deprecated Plugin filtering is now handled by {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}.
+     * This method is a no-op and will be removed in Grails 8.0.0.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    @Override
+    public void setPluginFilter(PluginFilter pluginFilter) {
     }
 
     public void informOfClassChange(Class<?> aClass) {

--- a/grails-core/src/main/groovy/org/grails/plugins/BinaryGrailsPluginDescriptor.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/BinaryGrailsPluginDescriptor.java
@@ -1,0 +1,59 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins;
+
+import java.util.List;
+
+import org.springframework.core.io.Resource;
+
+import org.apache.grails.core.plugins.GrailsPluginDescriptor;
+
+/**
+ * @deprecated Use {@link org.apache.grails.core.plugins.GrailsPluginDescriptor} instead.
+ * This compatibility bridge will be removed in Grails 8.0.0.
+ */
+@Deprecated(forRemoval = true, since = "7.1")
+public class BinaryGrailsPluginDescriptor {
+
+    private final GrailsPluginDescriptor descriptor;
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.GrailsPluginDescriptor} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public BinaryGrailsPluginDescriptor(Resource resource, List<String> classNames) {
+        this.descriptor = new GrailsPluginDescriptor(resource, List.of(), classNames);
+    }
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.GrailsPluginDescriptor#resource()} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public Resource getResource() {
+        return descriptor.resource();
+    }
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.GrailsPluginDescriptor#providedClasses()} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public List<String> getProvidedClassNames() {
+        return descriptor.providedClasses();
+    }
+}

--- a/grails-core/src/main/groovy/org/grails/plugins/CorePluginFinder.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/CorePluginFinder.java
@@ -1,0 +1,68 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins;
+
+import org.springframework.context.ApplicationContext;
+
+import grails.core.GrailsApplication;
+import grails.core.support.ParentApplicationContextAware;
+
+/**
+ * @deprecated Plugin discovery is now handled by {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}.
+ * This compatibility stub will be removed in Grails 8.0.0.
+ */
+@Deprecated(forRemoval = true, since = "7.1")
+public class CorePluginFinder implements ParentApplicationContextAware {
+
+    public static final String CORE_PLUGIN_PATTERN = "META-INF/grails-plugin.xml";
+
+    private static final String UNSUPPORTED_MESSAGE = "CorePluginFinder is no longer supported. Use org.apache.grails.core.plugins.GrailsPluginDiscovery instead.";
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.GrailsPluginDiscovery} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public CorePluginFinder(GrailsApplication application) {
+    }
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.GrailsPluginDiscovery} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public Class<?>[] getPluginClasses() {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.GrailsPluginDiscovery} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public BinaryGrailsPluginDescriptor getBinaryDescriptor(Class<?> pluginClass) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.GrailsPluginDiscovery} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    @Override
+    public void setParentApplicationContext(ApplicationContext parent) {
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
+    }
+}

--- a/grails-core/src/main/groovy/org/grails/plugins/CorePluginFinder.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/CorePluginFinder.java
@@ -18,17 +18,14 @@
  */
 package org.grails.plugins;
 
-import org.springframework.context.ApplicationContext;
-
 import grails.core.GrailsApplication;
-import grails.core.support.ParentApplicationContextAware;
 
 /**
  * @deprecated Plugin discovery is now handled by {@link org.apache.grails.core.plugins.GrailsPluginDiscovery}.
  * This compatibility stub will be removed in Grails 8.0.0.
  */
 @Deprecated(forRemoval = true, since = "7.1")
-public class CorePluginFinder implements ParentApplicationContextAware {
+public class CorePluginFinder {
 
     public static final String CORE_PLUGIN_PATTERN = "META-INF/grails-plugin.xml";
 
@@ -54,15 +51,6 @@ public class CorePluginFinder implements ParentApplicationContextAware {
      */
     @Deprecated(forRemoval = true, since = "7.1")
     public BinaryGrailsPluginDescriptor getBinaryDescriptor(Class<?> pluginClass) {
-        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
-    }
-
-    /**
-     * @deprecated Use {@link org.apache.grails.core.plugins.GrailsPluginDiscovery} instead.
-     */
-    @Deprecated(forRemoval = true, since = "7.1")
-    @Override
-    public void setParentApplicationContext(ApplicationContext parent) {
         throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
     }
 }

--- a/grails-core/src/main/groovy/org/grails/plugins/ExcludingPluginFilter.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/ExcludingPluginFilter.java
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins;
+
+import java.util.Set;
+
+/**
+ * @deprecated Use {@link org.apache.grails.core.plugins.filters.ExcludingPluginFilter} instead.
+ * This compatibility bridge will be removed in Grails 8.0.0.
+ */
+@Deprecated(forRemoval = true, since = "7.1")
+public class ExcludingPluginFilter extends org.apache.grails.core.plugins.filters.ExcludingPluginFilter {
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.filters.ExcludingPluginFilter#ExcludingPluginFilter(Set)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public ExcludingPluginFilter(Set<String> excluded) {
+        super(excluded);
+    }
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.filters.ExcludingPluginFilter#ExcludingPluginFilter(String[])} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public ExcludingPluginFilter(String[] excluded) {
+        super(excluded);
+    }
+}

--- a/grails-core/src/main/groovy/org/grails/plugins/MockGrailsPluginDiscovery.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/MockGrailsPluginDiscovery.java
@@ -22,6 +22,7 @@ import grails.plugins.GrailsPlugin;
 import org.apache.grails.core.plugins.DefaultGrailsPluginDiscovery;
 import org.apache.grails.core.plugins.GrailsPluginInfo;
 import org.apache.grails.core.plugins.GrailsPluginUtils;
+import org.springframework.core.env.Environment;
 
 public class MockGrailsPluginDiscovery extends DefaultGrailsPluginDiscovery {
 
@@ -32,6 +33,14 @@ public class MockGrailsPluginDiscovery extends DefaultGrailsPluginDiscovery {
 
     public MockGrailsPluginDiscovery(Class<?>[] pluginClasses) {
         super(pluginClasses);
+    }
+
+    /**
+     * No-op: mock discovery does not scan the classpath.
+     * Plugins are registered manually via {@link #registerMockPlugin}.
+     */
+    @Override
+    public void init(Environment environment) {
     }
 
     public void registerMockPlugin(GrailsPlugin plugin) {

--- a/grails-core/src/main/groovy/org/grails/plugins/MockGrailsPluginDiscovery.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/MockGrailsPluginDiscovery.java
@@ -18,29 +18,25 @@
  */
 package org.grails.plugins;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+
 import grails.plugins.GrailsPlugin;
 import org.apache.grails.core.plugins.DefaultGrailsPluginDiscovery;
 import org.apache.grails.core.plugins.GrailsPluginInfo;
 import org.apache.grails.core.plugins.GrailsPluginUtils;
-import org.springframework.core.env.Environment;
 
 public class MockGrailsPluginDiscovery extends DefaultGrailsPluginDiscovery {
 
     public MockGrailsPluginDiscovery() {
         super();
-        reset(); // do not search on the classpath by default
+        initPluginsIfNotDefined();
     }
 
     public MockGrailsPluginDiscovery(Class<?>[] pluginClasses) {
         super(pluginClasses);
-    }
-
-    /**
-     * No-op: mock discovery does not scan the classpath.
-     * Plugins are registered manually via {@link #registerMockPlugin}.
-     */
-    @Override
-    public void init(Environment environment) {
     }
 
     public void registerMockPlugin(GrailsPlugin plugin) {
@@ -61,7 +57,13 @@ public class MockGrailsPluginDiscovery extends DefaultGrailsPluginDiscovery {
 
     private void initPluginsIfNotDefined() {
         if (plugins == null) {
-            reset();
+            plugins = new LinkedHashMap<>();
+            loadOrderedPlugins = new ArrayList<>();
+            orderedPlugins = new ArrayList<>();
+            pluginToObserverMap = new HashMap<>();
+            delayedLoadPlugins = new LinkedList<>();
+            failedPlugins = new HashMap<>();
+            delayedEvictions = new HashMap<>();
         }
     }
 }

--- a/grails-core/src/main/groovy/org/grails/plugins/PluginFilterRetriever.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/PluginFilterRetriever.java
@@ -1,0 +1,93 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+
+import grails.config.Config;
+import grails.config.Settings;
+import grails.plugins.PluginFilter;
+
+/**
+ * @deprecated Use {@link org.apache.grails.core.plugins.filters.PluginFilterRetriever} instead.
+ * This compatibility bridge will be removed in Grails 8.0.0.
+ */
+@Deprecated(forRemoval = true, since = "7.1")
+public class PluginFilterRetriever extends org.apache.grails.core.plugins.filters.PluginFilterRetriever {
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.filters.PluginFilterRetriever#getPluginFilter(Environment)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    public PluginFilter getPluginFilter(Config config) {
+        if (config == null) {
+            throw new IllegalArgumentException("Config should not be null");
+        }
+
+        if (config instanceof Environment environment) {
+            return super.getPluginFilter(environment);
+        }
+
+        Object includes = config.getProperty(Settings.PLUGIN_INCLUDES, Object.class, null);
+        Object excludes = config.getProperty(Settings.PLUGIN_EXCLUDES, Object.class, null);
+        return getPluginFilter(includes, excludes);
+    }
+
+    /**
+     * @deprecated Use {@link org.apache.grails.core.plugins.filters.PluginFilterRetriever#getPluginFilter(Environment)} instead.
+     */
+    @Deprecated(forRemoval = true, since = "7.1")
+    PluginFilter getPluginFilter(Object includes, Object excludes) {
+        if (includes != null) {
+            if (includes instanceof Collection<?> includesCollection) {
+                return new org.apache.grails.core.plugins.filters.IncludingPluginFilter(toSet(includesCollection));
+            }
+            return new org.apache.grails.core.plugins.filters.IncludingPluginFilter(StringUtils.commaDelimitedListToStringArray(includes.toString()));
+        }
+
+        if (excludes != null) {
+            if (excludes instanceof Collection<?> excludesCollection) {
+                return new org.apache.grails.core.plugins.filters.ExcludingPluginFilter(toSet(excludesCollection));
+            }
+            return new org.apache.grails.core.plugins.filters.ExcludingPluginFilter(StringUtils.commaDelimitedListToStringArray(excludes.toString()));
+        }
+
+        return new org.apache.grails.core.plugins.filters.NoOpPluginFilter();
+    }
+
+    private static Set<String> toSet(Collection<?> values) {
+        var set = new LinkedHashSet<String>();
+        for (Object v : values) {
+            if (v == null) {
+                continue;
+            }
+
+            String s = v.toString().trim();
+            if (!s.isEmpty()) {
+                set.add(s);
+            }
+        }
+        return set;
+    }
+}

--- a/grails-core/src/main/groovy/org/grails/plugins/PluginFilterRetriever.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/PluginFilterRetriever.java
@@ -18,76 +18,28 @@
  */
 package org.grails.plugins;
 
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.Set;
-
-import org.springframework.core.env.Environment;
-import org.springframework.util.StringUtils;
-
 import grails.config.Config;
-import grails.config.Settings;
 import grails.plugins.PluginFilter;
 
 /**
  * @deprecated Use {@link org.apache.grails.core.plugins.filters.PluginFilterRetriever} instead.
- * This compatibility bridge will be removed in Grails 8.0.0.
+ * This compatibility stub will be removed in Grails 8.0.0.
  */
 @Deprecated(forRemoval = true, since = "7.1")
 public class PluginFilterRetriever extends org.apache.grails.core.plugins.filters.PluginFilterRetriever {
 
+    private static final String UNSUPPORTED_MESSAGE =
+            "PluginFilterRetriever.getPluginFilter(Config) is no longer supported. " +
+            "Use org.apache.grails.core.plugins.filters.PluginFilterRetriever.getPluginFilter(Environment) instead.";
+
     /**
-     * @deprecated Use {@link org.apache.grails.core.plugins.filters.PluginFilterRetriever#getPluginFilter(Environment)} instead.
+     * @deprecated Use {@link org.apache.grails.core.plugins.filters.PluginFilterRetriever#getPluginFilter(org.springframework.core.env.Environment)} instead.
+     * The Environment always has all configuration, so it is adaptable for all use cases.
+     *
+     * @throws UnsupportedOperationException always
      */
     @Deprecated(forRemoval = true, since = "7.1")
     public PluginFilter getPluginFilter(Config config) {
-        if (config == null) {
-            throw new IllegalArgumentException("Config should not be null");
-        }
-
-        if (config instanceof Environment environment) {
-            return super.getPluginFilter(environment);
-        }
-
-        Object includes = config.getProperty(Settings.PLUGIN_INCLUDES, Object.class, null);
-        Object excludes = config.getProperty(Settings.PLUGIN_EXCLUDES, Object.class, null);
-        return getPluginFilter(includes, excludes);
-    }
-
-    /**
-     * @deprecated Use {@link org.apache.grails.core.plugins.filters.PluginFilterRetriever#getPluginFilter(Environment)} instead.
-     */
-    @Deprecated(forRemoval = true, since = "7.1")
-    PluginFilter getPluginFilter(Object includes, Object excludes) {
-        if (includes != null) {
-            if (includes instanceof Collection<?> includesCollection) {
-                return new org.apache.grails.core.plugins.filters.IncludingPluginFilter(toSet(includesCollection));
-            }
-            return new org.apache.grails.core.plugins.filters.IncludingPluginFilter(StringUtils.commaDelimitedListToStringArray(includes.toString()));
-        }
-
-        if (excludes != null) {
-            if (excludes instanceof Collection<?> excludesCollection) {
-                return new org.apache.grails.core.plugins.filters.ExcludingPluginFilter(toSet(excludesCollection));
-            }
-            return new org.apache.grails.core.plugins.filters.ExcludingPluginFilter(StringUtils.commaDelimitedListToStringArray(excludes.toString()));
-        }
-
-        return new org.apache.grails.core.plugins.filters.NoOpPluginFilter();
-    }
-
-    private static Set<String> toSet(Collection<?> values) {
-        var set = new LinkedHashSet<String>();
-        for (Object v : values) {
-            if (v == null) {
-                continue;
-            }
-
-            String s = v.toString().trim();
-            if (!s.isEmpty()) {
-                set.add(s);
-            }
-        }
-        return set;
+        throw new UnsupportedOperationException(UNSUPPORTED_MESSAGE);
     }
 }


### PR DESCRIPTION
## Summary

Adds deprecated bridge shims so the plugin configuration refactoring can land in **7.1.x** without breaking existing public API. All bridges are marked `@Deprecated(forRemoval = true, since = "7.1")` for clean removal in **8.0.0**.

The shim methods `setLoadCorePlugins` and `setPluginFilter` now forward settings to `GrailsPluginDiscovery` and trigger `reset()`/`init()` when an application context is available, making them behave the same as the original API.

## Motivation

The `conditionalPluginConfiguration` branch removes several public APIs. While the refactoring is solid, shipping these removals in a minor release (7.1.x) would break existing consumers. These bridges preserve backward compatibility by delegating to the new implementations.

## What's Added

### Interface / Abstract Class Bridges

- **`GrailsPluginManager.setLoadCorePlugins(boolean)`** - deprecated default method
- **`GrailsPluginManager.setPluginFilter(PluginFilter)`** - deprecated default method
- **`AbstractGrailsPluginManager`** - concrete implementations that forward settings to `GrailsPluginDiscovery` and call `reset()`/`init()` to rediscover plugins when an application context is available

### Constructor Bridges (delegate to new API)

- **`DefaultGrailsPluginManager(String, GrailsApplication)`** - forwards resource path to `DefaultGrailsPluginDiscovery(String)`
- **`DefaultGrailsPluginManager(String[], GrailsApplication)`** - forwards resource paths to `DefaultGrailsPluginDiscovery(String[])`
- **`DefaultGrailsPluginManager(Class<?>[], GrailsApplication)`** - forwards plugin classes to `DefaultGrailsPluginDiscovery(Class<?>[])`
- **`GrailsApplicationPostProcessor(GrailsApplicationLifeCycle, ApplicationContext, Class...)`** - resolves `GrailsPluginDiscovery` from the application context via `containsBean(BEAN_NAME)` before falling back to a new instance, avoiding duplicate discovery creation
- **`GrailsApplicationPostProcessor.customizePluginManager()`** - empty stub

### Wrapper Classes in Old Packages (`org.grails.plugins`)

- **`ExcludingPluginFilter`** - extends `o.a.g.c.plugins.filters.ExcludingPluginFilter`
- **`PluginFilterRetriever`** - extends `o.a.g.c.plugins.filters.PluginFilterRetriever` with `Config`-based overload
- **`BinaryGrailsPluginDescriptor`** - wraps new `GrailsPluginDescriptor` record
- **`CorePluginFinder`** - deprecated stub (no longer implements `ParentApplicationContextAware` since the original never did)

### Plugin Discovery Reinitialization Support

- **`DefaultGrailsPluginDiscovery`** - added `initialized` boolean flag so `reset()` + `init()` actually rediscovers plugins instead of being blocked by the old `plugins == null` guard
- **`MockGrailsPluginDiscovery`** - overrides `init()` as no-op to prevent classpath scanning on mocks
- **`AbstractGrailsPluginManager.reinitializeDiscovery()`** - private method that calls `reset()` + `init()` on discovery with `applicationContext` null guard for pre-startup safety

## Key Design Decisions

1. **Shim methods forward settings and trigger rediscovery** - `setLoadCorePlugins(boolean)` delegates to `pluginDiscovery.setLoadClasspathPlugins(boolean)` and `setPluginFilter(PluginFilter)` delegates to `pluginDiscovery.setPluginFilter(PluginFilter)`. Both call `reinitializeDiscovery()` which resets and reinitializes discovery when an `ApplicationContext` is available. When called before the context is set (the typical pre-startup case), the forwarded settings are picked up during normal lifecycle initialization.

2. **`initialized` flag instead of null-checking `plugins`** - `DefaultGrailsPluginDiscovery.init()` previously guarded with `if (plugins == null)`, but `reset()` sets `plugins` to an empty `LinkedHashMap` (not null) so `reset()` + `init()` was a no-op. The new `initialized` boolean flag is set to `false` by `reset()` and `true` at the end of `populatePlugins()`, allowing `init()` to re-run after a reset. `validateInitialized()` still checks `plugins == null` since reset leaves valid empty maps.

3. **Mock discovery overrides `init()` as no-op** - `MockGrailsPluginDiscovery` is meant for tests that register plugins manually. Overriding `init()` prevents classpath scanning when shim methods trigger `reinitializeDiscovery()` on a mock.

4. **`GrailsApplicationPostProcessor` resolves discovery from context** - Uses `containsBean(GrailsPluginDiscovery.BEAN_NAME)` to reuse the singleton promoted by `GrailsBootstrapRegistryInitializer`, avoiding a duplicate uninitialized instance. Falls back to `new DefaultGrailsPluginDiscovery()` when no context/bean is available.

5. **`DefaultGrailsPluginManager` forwards constructor args** - Each deprecated constructor passes its arguments (`String`, `String[]`, `Class<?>[]`) to the matching `DefaultGrailsPluginDiscovery` constructor instead of discarding them with the no-arg constructor. No context lookup here since these constructors have no `ApplicationContext` parameter.

6. **`CorePluginFinder` does not implement `ParentApplicationContextAware`** - The original class never implemented this interface. Adding it with a throwing `setParentApplicationContext()` would cause failures when Spring/Grails attempts to inject the parent context.

## Removal Plan

All bridges carry:

```java
@Deprecated(forRemoval = true, since = "7.1")
```

with Javadoc pointing to the replacement API. In 8.0.0, delete every class/method marked with this annotation.

## Verification

- `./gradlew :grails-core:compileGroovy :grails-core:compileJava` - **PASS**
- `./gradlew :grails-core:test` - **PASS** (all 150+ tests)